### PR TITLE
Implement TypeScript support for appium-sdb.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
     "version": "1.0.1-beta",
     "description": "Smart Development Bridge interface",
     "main": "./build/index.js",
+    "types": "./typings/index.d.ts",
     "scripts": {
         "prepare": "gulp prepublish",
-        "test": "gulp once",
+        "test": "gulp once && npm run test:types",
+        "test:types": "tsc --lib es6,dom --esModuleInterop --noEmit ./typings/index.*.ts",
         "watch": "gulp watch",
         "build": "gulp transpile",
         "mocha": "mocha",
@@ -32,6 +34,7 @@
         "lib": "lib"
     },
     "files": [
+        "typings/index.d.ts",
         "index.js",
         "lib",
         "build/index.js",
@@ -50,6 +53,7 @@
         "precommit-test"
     ],
     "devDependencies": {
+        "@types/lodash": "^4.14.138",
         "appium-gulp-plugins": "^3.2.3",
         "babel-eslint": "^10.0.1",
         "eslint": "^5.10.0",
@@ -59,6 +63,7 @@
         "eslint-plugin-promise": "^4.0.0",
         "gulp": "^4.0.0",
         "mocha": "^5.2.0",
-        "pre-commit": "^1.1.3"
+        "pre-commit": "^1.1.3",
+        "typescript": "^3.6.3"
     }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,135 @@
+declare module 'appium-sdb' {
+  import _ from 'lodash';
+
+  export interface SDBProps {
+    sdkRoot?: any;
+    udid?: any;
+    executable: {
+      path: string;
+      defaultArgs: any[];
+    };
+    curDeviceId?: any;
+    emulatorPort?: any;
+    binaries: object;
+    suppressKillServer?: any;
+    sdbPort?: number;
+    remoteSdbPort?: number;
+  }
+
+  type Device = { uuid: string; state: string; platform: string };
+
+  export class SDB {
+    constructor(opts?: SDBProps);
+
+    static createSDB(opts?: SDBProps): Promise<SDB>;
+
+    // SDB Commands
+
+    getSdbWithCorrectSdbPath(): Promise<SDB>;
+
+    isDeviceConnected(): Promise<boolean>;
+
+    mkdir(remotePath: string): Promise<any>;
+
+    isValidClass(classString: string): RegExpExecArray;
+
+    forceStop(pkg: string): Promise<any>;
+
+    getSdbPath(): string;
+
+    rimraf(path: string): Promise<any>;
+
+    push(localPath: string, remotePath: string, opts: string[]): Promise<any>;
+
+    pull(remotePath: string, localPath: string): Promise<any>;
+
+    processExists(processName: string): Promise<boolean>;
+
+    forwardPort(systemPort: number, devicePort: number): Promise<any>;
+
+    removePortForward(systemPort: number): Promise<any>;
+
+    ping(): Promise<boolean>;
+
+    restart(): Promise<any>;
+
+    takeScreenShot(): Promise<boolean>;
+
+    // System Call Methods
+
+    getConnectedDevices(): Promise<Device[]>;
+
+    getDeviceStatus(): Promise<'device' | 'offline' | 'locked' | 'unkown'>;
+
+    ConnectDevice(device: string | number): Promise<boolean>;
+
+    getDevicesWithRetry(timeoutMs?: number): Promise<any>;
+
+    restartSdb(): Promise<boolean>;
+
+    sdbExec(cmd: string, opts?: object): Promise<any>;
+
+    shell(cmd: string, opts?: object): Promise<any>;
+
+    getPortFromEmulatorString(emStr: string): Promise<number | boolean>;
+
+    getConnectedEmulators(): Promise<any[]>;
+
+    setDeviceId(deviceId: number | string): void;
+
+    setDevice(deviceObj: object): void;
+
+    getSdbVersion: (() => Promise<{
+      versionString: any;
+      versionFloat: number;
+      major: number;
+      minor: number;
+      patch: number;
+    }>) &
+      _.MemoizedFunction;
+
+    reboot(): Promise<boolean>;
+
+    root(): Promise<boolean>;
+
+    unroot(): Promise<boolean>;
+
+    fileExists(remotePath: string): Promise<boolean>;
+
+    ls(remotePath: string): Promise<any[]>;
+
+    getSdkBinaryPath(binaryName: string): Promise<string>;
+
+    getCommandForOS(): 'which' | 'where';
+
+    setEmulatorPort(emPort: number): void;
+
+    killProcess(process: string | number, opts?: object): Promise<boolean>;
+
+    checkProcessStatus(process: string | number, opts?: object): Promise<boolean>;
+
+    startExec(exec: string, opts?: object): Promise<void>;
+
+    stopAutoSleep(): Promise<void>;
+
+    startAutoSleep(): Promise<void>;
+
+    // TPK Utils
+
+    isAppInstalled(pkg: any): Promise<boolean>;
+
+    startApp(pkg: any, opts?: object): Promise<boolean>;
+
+    isStartedApp(pkg: any, opts?: object): Promise<boolean>;
+
+    uninstall(pkg: any): Promise<boolean>;
+
+    installFromDevicePath(tpkPathOnDevice: string | number): Promise<boolean>;
+
+    install(tpk: any, pkg?: any, replace?: boolean, timeout?: number): Promise<boolean>;
+  }
+
+  export const DEFAULT_SDB_PORT: number;
+
+  export default SDB;
+}

--- a/typings/index.test.ts
+++ b/typings/index.test.ts
@@ -1,0 +1,12 @@
+import SDB from 'appium-sdb';
+
+let sdb = new SDB();
+
+class Tester {
+  async Main() {
+    await SDB.createSDB();
+    console.log(await sdb.getConnectedDevices());
+  }
+}
+
+const tester = new Tester();


### PR DESCRIPTION
Hi 👋, I wanted to see if we could add TypeScript support for this module along with existing es6, async, and await!

By adding type def, OSS community users should be able to use this module in their `TypeScript` projects.

### Includes

- Add TypeDefinition file to `appium-sdb` module.